### PR TITLE
Fix missing new keyword in error constructors and redundant true && in logic

### DIFF
--- a/restored-src/src/commands.ts
+++ b/restored-src/src/commands.ts
@@ -704,7 +704,7 @@ export function hasCommand(commandName: string, commands: Command[]): boolean {
 export function getCommand(commandName: string, commands: Command[]): Command {
   const command = findCommand(commandName, commands)
   if (!command) {
-    throw ReferenceError(
+    throw new ReferenceError(
       `Command ${commandName} not found. Available commands: ${commands
         .map(_ => {
           const name = getCommandName(_)

--- a/restored-src/src/commands/chrome/chrome.tsx
+++ b/restored-src/src/commands/chrome/chrome.tsx
@@ -186,7 +186,7 @@ function ClaudeInChromeMenu(t0) {
   } else {
     options = $[8];
   }
-  const isDisabled = isWSL || true && !isClaudeAISubscriber;
+  const isDisabled = isWSL || !isClaudeAISubscriber;
   let t5;
   if ($[18] !== onDone) {
     t5 = () => onDone();

--- a/restored-src/src/utils/claudeInChrome/setup.ts
+++ b/restored-src/src/utils/claudeInChrome/setup.ts
@@ -193,7 +193,7 @@ export async function installChromeNativeHostManifest(
 ): Promise<void> {
   const manifestDirs = getNativeMessagingHostsDirs()
   if (manifestDirs.length === 0) {
-    throw Error('Claude in Chrome Native Host not supported on this platform')
+    throw new Error('Claude in Chrome Native Host not supported on this platform')
   }
 
   const manifest = {


### PR DESCRIPTION
## Summary

- **`restored-src/src/commands.ts:707`**: `throw ReferenceError()` → `throw new ReferenceError()` — missing `new` keyword
- **`restored-src/src/utils/claudeInChrome/setup.ts:196`**: `throw Error()` → `throw new Error()` — same issue
- **`restored-src/src/commands/chrome/chrome.tsx:189`**: Remove redundant `true &&` in `isWSL || true && !isClaudeAISubscriber` — due to operator precedence, the expression always evaluates to true for non-subscribers

🤖 Generated with [Claude Code](https://claude.com/claude-code)