### PR TITLE
chore: add .gitignore for node_modules, OS files, and editor artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,25 @@
+# Node.js dependencies
+node_modules/
+
+# Extraction output (re-creatable from extract-sources.js)
+# Uncomment the line below if you prefer not to track restored-src
+# restored-src/
+
+# OS-generated files
+.DS_Store
+Thumbs.db
+
+# Editor directories and files
+.idea/
+.vscode/
+*.swp
+*.swo
+*~
+
+# Logs
+*.log
+npm-debug.log*
+
+# Environment files
+.env
+.env.local


### PR DESCRIPTION
## Summary

- Adds a standard `.gitignore` file to prevent accidentally committing common unwanted files in future contributions
- Ignores `node_modules/` directories (if someone installs `source-map` to run `extract-sources.js`)
- Ignores OS-generated files: `.DS_Store` (macOS), `Thumbs.db` (Windows)
- Ignores editor/IDE config directories: `.idea/` (JetBrains), `.vscode/` (VS Code)
- Ignores log files and environment files

## Motivation

The repo currently has no `.gitignore`. If contributors clone the repo and run `npm install` (to install the `source-map` dependency needed by `extract-sources.js`), the resulting `node_modules/` directory would show up as untracked files. This `.gitignore` prevents such accidental commits.

A commented-out entry for `restored-src/` is also included in case future maintainers prefer not to track the extracted source in git (since it can be regenerated from `extract-sources.js`).

🤖 Generated with [Claude Code](https://claude.ai/claude-code)